### PR TITLE
Exclusion improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,27 @@ In the `docker-compose.yml` file, you should configure the following:
 - OPTIONAL for Plane-Alert: You can add custom fields, that (again optionally) are displayed on the Plane-Alert list. See [this discussion](https://github.com/kx1t/docker-planefence/issues/38) on how to do that.
 - OPTIONAL: The website will apply background pictures if you provide them. Save your .jpg pictures as `/opt/adsb/planefence/config/pf_background.jpg` for Planefence and `/opt/adsb/planefence/config/pa_background.jpg` for Plane-Alert. (You may have to restart the container or do `touch /opt/adsb/planefence/config/planefence.config` in order for these backgrounds to become effective.)
 - OPTIONAL: Add images of tar1090 to your Tweets in Planefence and Plane-Alert. In order to enable this, simply add the `pf-screenshot` section to your `Docker-compose.yml` file as per the example in this repo's [`docker-compose.yml`](https://github.com/sdr-enthusiasts/docker-planefence/blob/main/docker-compose.yml) file. Note - to simplify configuration, Planefence assumes that the hostname of the screenshotting image is called `pf-screenshot` and that it's reachable under that name from the Planefence container stack.
-- OPTIONAL: Show [OpenAIP](http://map.openaip.net) overlay on Planefence web page heatmap. Enable this by setting the option `PF_OPENAIP_LAYER=ON` in `~/.planefence/planefence.config`
+- OPTIONAL: Show [OpenAIP](http://map.openaip.net) overlay on Planefence web page heatmap. Enable this by setting the option `PF_OPENAIP_LAYER=ON` in `/opt/adsb/planefence/config/planefence.config`
+
+#### Plane-Alert Exclusions
+
+In some circumstances you may wish to blacklist certain planes, or types of planes, from appearing in Plane-Alert and its Mastodon and Discord posts. This may be desireable if, for example, you're located near Pensacola, Florida, where you would be bombarded daily by dozens of notifications about US Navy T-6 Texan II training aircraft, which could drown out more interesting planes. Excluding planes can be accomplished using the `PA_EXCLUSIONS=` parameter in `/opt/adsb/planefence/config/planefence.config`. Currently, you may exclude whole ICAO Types (such as `TEX2` to remove all T-6 Texan IIs), specific ICAO hexes (e.g. `AE1ECB`), specific registrations and tail codes (e.g. `N24HD` or `92-03327`), or any freeform string (e.g. `UC-12`, `Mayweather`, `Kid Rock`). Multiple exclusions should be separated by commas. It is case insensitive. An example:
+```yml
+PA_EXCLUSIONS=tex2,AE06D9,ae27fe,Floyd Mayweather,UC-12W
+```
+This would exclude *all* T-6 Texan IIs, the planes with ICAO hexes `AE06D9 (a Marine Corps UC-12F Huron) and `AE27FE` (a Coast Guard MH-60T), any planes with "Floyd Mayweather" anywhere in the database entry, and any planes with "UC-12W" anywhere in the database entry. 
+
+*Please note:* this is a **powerful feature** which may produce unintended consequences. You should verify that it's working correctly by examining the logs after making changes to `planefence.config`. You should see, e.g.:
+```
+tex2 appears to be an ICAO type and is valid, entries excluded: 479
+AE06D9 appears to be an ICAO hex and is valid, entries excluded: 1
+ae27fe appears to be an ICAO hex and is valid, entries excluded: 1
+Floyd Mayweather appears to be a freeform search pattern, entries excluded: 1
+UC-12W appears to be a freeform search pattern, entries excluded: 8
+490 entries excluded.
+```
+
+Also note that after adding exclusions, any pre-existing entries for those excluded planes in your Plane Alert web user interface will not be entirely removed, but some fields will disappear. If you've made a mistake and revert your exclusion changes to `planefence.config`, affected entries in your web user interface will be fully restored after a few minutes.
 
 #### Applying your setup
 
@@ -148,7 +168,7 @@ Note that the `call` parameter (see below) will start with `@` followed by the c
 - Plane-alert will appear at http://myip:8088/plane-alert
 - Twitter setup is complex and Elon will ban you if you publish anything about one of his planes. [Here](https://github.com/sdr-enthusiasts/docker-planefence#setting-up-tweeting)'s a description on what to do. We advice you to skip Twitter and send notifications to [Mastodon](https://github.com/sdr-enthusiasts/docker-planefence/README-Mastodon.md) instead.
 - Error "We cannot reach {host} on port 30003". This could be caused by a few things:
-  - Did you set the correct hostname or IP address in `PF_SOCK30003HOST` in `planefence.config`? This can be either an IP address, or an external hostname, or the name of another container in the same stack (in which case you use your machine's IP address).
+  - Did you set the correct hostname or IP address in `PF_SOCK30003HOST` in `planefence.config`? This can be either an IP address, or an external hostname, or the name of another container in the same stack.
   - Did you enable SBS (BaseStation -- *not* Beast!) output? Here are some hints on how to enable this:
    - For non-containerized `dump1090[-fa]`/`readsb`/`tar1090`: add command line option `--net-sbs-port 30003`
    - For containerized `readsb-protobuf`: add to the `environment:` section of your `docker-compose.yml` file:

--- a/README.md
+++ b/README.md
@@ -93,15 +93,17 @@ In the `docker-compose.yml` file, you should configure the following:
 - OPTIONAL: Add images of tar1090 to your Tweets in Planefence and Plane-Alert. In order to enable this, simply add the `pf-screenshot` section to your `Docker-compose.yml` file as per the example in this repo's [`docker-compose.yml`](https://github.com/sdr-enthusiasts/docker-planefence/blob/main/docker-compose.yml) file. Note - to simplify configuration, Planefence assumes that the hostname of the screenshotting image is called `pf-screenshot` and that it's reachable under that name from the Planefence container stack.
 - OPTIONAL: Show [OpenAIP](http://map.openaip.net) overlay on Planefence web page heatmap. Enable this by setting the option `PF_OPENAIP_LAYER=ON` in `/opt/adsb/planefence/config/planefence.config`
 
+---
+
 #### Plane-Alert Exclusions
 
-In some circumstances you may wish to blacklist certain planes, or types of planes, from appearing in Plane-Alert and its Mastodon and Discord posts. This may be desireable if, for example, you're located near Pensacola, Florida, where you would be bombarded daily by dozens of notifications about US Navy T-6 Texan II training aircraft, which could drown out more interesting planes. Excluding planes can be accomplished using the `PA_EXCLUSIONS=` parameter in `/opt/adsb/planefence/config/planefence.config`. Currently, you may exclude whole ICAO Types (such as `TEX2` to remove all T-6 Texan IIs), specific ICAO hexes (e.g. `AE1ECB`), specific registrations and tail codes (e.g. `N24HD` or `92-03327`), or any freeform string (e.g. `UC-12`, `Mayweather`, `Kid Rock`). Multiple exclusions should be separated by commas. It is case insensitive. An example:
+In some circumstances you may wish to blacklist certain planes, or types of planes, from appearing in Plane-Alert and its Mastodon and Discord posts. This may be desireable if, for example, you're located near a military flight training base, where you could be flooded with dozens of notifications about T-6 Texan training aircraft every day, which could drown out more interesting planes. To that end, excluding planes can be accomplished using the `PA_EXCLUSIONS=` parameter in `/opt/adsb/planefence/config/planefence.config`. Currently, you may exclude whole ICAO Types (such as `TEX2` to remove all T-6 Texans), specific ICAO hexes (e.g. `AE1ECB`), specific registrations and tail codes (e.g. `N24HD` or `92-03327`), or any freeform string (e.g. `UC-12`, `Mayweather`, `Kid Rock`). Multiple exclusions should be separated by commas. It is case insensitive. An example:
 ```yml
 PA_EXCLUSIONS=tex2,AE06D9,ae27fe,Floyd Mayweather,UC-12W
 ```
-This would exclude *all* T-6 Texan IIs, the planes with ICAO hexes `AE06D9 (a Marine Corps UC-12F Huron) and `AE27FE` (a Coast Guard MH-60T), any planes with "Floyd Mayweather" anywhere in the database entry, and any planes with "UC-12W" anywhere in the database entry. 
+This would exclude *all* T-6 Texans, the planes with ICAO hexes `AE06D9` (a Marine Corps UC-12F Huron) and `AE27FE` (a Coast Guard MH-60T), any planes with "Floyd Mayweather" anywhere in the database entry, and any planes with "UC-12W" anywhere in the database entry. URLs and image links are intentionally not searched.
 
-*Please note:* this is a **powerful feature** which may produce unintended consequences. You should verify that it's working correctly by examining the logs after making changes to `planefence.config`. You should see, e.g.:
+*Please note:* this is a **powerful feature** which may produce unintended consequences. You should verify that it's working correctly by examining the container logs after making changes to `planefence.config`. You should see, e.g.:
 ```
 tex2 appears to be an ICAO type and is valid, entries excluded: 479
 AE06D9 appears to be an ICAO hex and is valid, entries excluded: 1
@@ -112,6 +114,8 @@ UC-12W appears to be a freeform search pattern, entries excluded: 8
 ```
 
 Also note that after adding exclusions, any pre-existing entries for those excluded planes in your Plane Alert web user interface will not be entirely removed, but some fields will disappear. If you've made a mistake and revert your exclusion changes to `planefence.config`, affected entries in your web user interface will be fully restored after a few minutes.
+
+---
 
 #### Applying your setup
 

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -66,7 +66,7 @@ if [[ $inhibit_update == "false" ]]; then
 		elif [[ -n "$TYPE" ]]
 		then
 			echo "$TYPE appears to be a freeform search pattern, I dearly hope you know what you're doing!"
-			sed -r -i "/,[A-Za-z0-9 ]*$TYPE[A-Za-z0-9 ]*,/Id /usr/share/planefence/persist/.internal/plane-alert-db.txt
+			sed -r -i "/,[A-Za-z0-9 ]*$TYPE[A-Za-z0-9 ]*,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		else
 			echo "$TYPE is invalid, skipping!"
 		fi

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -49,7 +49,7 @@ done
 
 if [[ $inhibit_update == "false" ]]; then
 	touch /usr/share/planefence/persist/.internal/plane-alert-db.txt
-	cat /tmp/alertlist*.txt |  tr -dc "[:alnum:][:blank:]:/?&=%#\$\\\[\].,\{\};\-_\n" | awk -F',' '!seen[$1]++'  >/usr/share/planefence/persist/.internal/plane-alert-db.txt 2>/dev/null
+	cat /tmp/alertlist*.txt |  tr -dc "[:alnum:][:blank:]+':/?&=%#\$\\\[\].,\{\};\-_\n" | awk -F',' '!seen[$1]++'  >/usr/share/planefence/persist/.internal/plane-alert-db.txt 2>/dev/null
 	EXCLUDE="$(sed -n 's|^\s*PA_EXCLUSIONS=\(.*\)|\1|p' /usr/share/planefence/persist/planefence.config)"
 	[[ "$EXCLUDE" != "" ]] && IFS="," read -ra EXCLUSIONS <<< "$EXCLUDE"
 	count_start="$(wc -l < /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
@@ -57,15 +57,15 @@ if [[ $inhibit_update == "false" ]]; then
 	do
 		if (("${#TYPE} >= 3")) && (("${#TYPE} <= 4"))
 		then
-			echo "$TYPE appears to be an ICAO type and is valid, removing."
+			echo "$TYPE appears to be an ICAO type and is valid, entries excluded:" "$(grep -ci "$TYPE" /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
 			sed -i "/,$TYPE,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		elif [[ "$TYPE" =~ ^[0-9a-fA-F]{6}$ ]]
 		then
-			echo "$TYPE appears to be an ICAO hex and is valid, removing."
+			echo "$TYPE appears to be an ICAO hex and is valid, entries excluded:" "$(grep -ci "$TYPE" /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
 			sed -r -i "/^$TYPE,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		elif [[ -n "$TYPE" ]]
 		then
-			echo "$TYPE appears to be a freeform search pattern, I dearly hope you know what you're doing!"
+			echo "$TYPE appears to be a freeform search pattern, entries excluded:" "$(grep -ci "$TYPE" /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
 			sed -r -i "/,[A-Za-z0-9\-\.\+ ]*$TYPE[A-Za-z0-9\-\.\+ ]*,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		else
 			echo "$TYPE is invalid, skipping!"

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -63,6 +63,10 @@ if [[ $inhibit_update == "false" ]]; then
 		then
 			echo "$TYPE appears to be an ICAO hex and is valid, removing."
 			sed -r -i "/^$TYPE,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
+		elif [[ -n "$TYPE" ]]
+		then
+			echo "$TYPE appears to be a freeform search pattern, I dearly hope you know what you're doing!"
+			sed -r -i "/,[A-Za-z0-9 ]*$TYPE[A-Za-z0-9 ]*,/Id /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		else
 			echo "$TYPE is invalid, skipping!"
 		fi

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -66,7 +66,7 @@ if [[ $inhibit_update == "false" ]]; then
 		elif [[ -n "$TYPE" ]]
 		then
 			echo "$TYPE appears to be a freeform search pattern, I dearly hope you know what you're doing!"
-			sed -r -i "/,[A-Za-z0-9 ]*$TYPE[A-Za-z0-9 ]*,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
+			sed -r -i "/,[A-Za-z0-9\-\.\+ ]*$TYPE[A-Za-z0-9\-\.\+ ]*,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		else
 			echo "$TYPE is invalid, skipping!"
 		fi

--- a/rootfs/usr/share/planefence/stage/planefence.config
+++ b/rootfs/usr/share/planefence/stage/planefence.config
@@ -387,3 +387,12 @@ MASTODON_ACCESS_TOKEN=
 PF_MASTODON_VISIBILITY=unlisted
 PA_MASTODON_VISIBILITY=unlisted
 #
+#
+# ---------------------------------------------------------------------
+# Plane-Alert Exclusions. Entries here will be excluded from Plane-Alert notifications on Mastodon and Discord, 
+# and won't be recorded in the Plane-Alert web UI. Accepted values are ICAO type codes (e.g. TEX2 for T-6 Texans),
+# ADS-B hex codes (e.g. AE06D9), or any string found in the plane's database entry (e.g. N24HD, 92-03327, UC-12W,
+# Kid Rock, ambulance, et cetera). Multiple exclusions should be separated by commas. Entries are not case sensitive.
+# After making additions or changes, examine the container logs to verify it's doing what you intended it to!
+# Note that URLs and image links are not searched. Leave this blank to disable.
+PA_EXCLUSIONS=


### PR DESCRIPTION
This PR introduces freeform exclusions, improved logging of exclusions, explanation of the feature in the readme, addition of the variable to `planefence.config`, and makes tweaks to the csv-to-txt sanitization routine.

The elif statement that captures freeform stuff probably needs improvement, as I don't think it'll ever be blank since that check is performed previously. Likewise the final `else` statement won't ever be triggered. I'm not sure about the best way to improve these conditionals.

I thought about adding an elif to catch military tail codes:
```sh
elif [[ "$TYPE" =~ ^[0-9]{2}\-?[0-9]{2,5}$ ]]
then
  echo "$TYPE appears to be a military tail code and is valid, entries excluded:" "$(grep -ci "$TYPE" /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
  <appropriate sed command>
```
But with freeform matching there's really no point, beyond some bespoke logging.

---

Improved logging: now shows the number of database records matched for each token:
```
tex2 appears to be an ICAO type and is valid, entries excluded: 479
AE06D9 appears to be an ICAO hex and is valid, entries excluded: 1
ae4dff appears to be an ICAO hex and is valid, entries excluded: 1
Floyd Mayweather appears to be a freeform search pattern, entries excluded: 1
482 entries excluded.
```

---

Sanitization tweaks: `get-pa-alertlist.sh` builds the `plane-alert-db.txt` file from the `plane-alert-db.csv` files from Github. During that process, some characters are removed. Since several plane types have +s in their names, and since some categories use apostrophes, this tweak now allows `+` and `'` characters through to the .txt file. This should theoretically fix this: 
![image](https://github.com/Phaeton/docker-planefence/assets/7931765/2f450dbb-33fb-4580-832c-68124fc589be)
But we should keep an eye on it to make sure it doesn't start a fire somewhere.

---

Information and examples about the exclusion feature has been added to the repo's readme. It may be too verbose and could be trimmed down some. Also, `PA_EXCLUSIONS=` has been added to the bottom of the stock `planefence.config` file, and a short blurb about its usage has been added as well.